### PR TITLE
Implement CORE-003d: NVIDIA GPU Operator

### DIFF
--- a/.github/issues/CORE-003d-gpu-operator.md
+++ b/.github/issues/CORE-003d-gpu-operator.md
@@ -1,0 +1,87 @@
+---
+name: Component Requirement
+about: Define a requirement for deploying a Thinkube component
+title: '[CORE-003d] Deploy NVIDIA GPU Operator'
+labels: requirement, milestone-2
+assignees: ''
+---
+
+## Component Requirement
+
+### Description
+Deploy the NVIDIA GPU Operator to enable GPU support in the Kubernetes cluster, allowing GPU hardware to be discovered, managed, and utilized by containerized workloads. The GPU Operator automates driver installation, GPU device plugin, container runtime, and more.
+
+**IMPORTANT**: This is a minimal migration requirement. The reference playbook is already well-structured with few dependencies. NVIDIA drivers are already installed and tested on the host systems. The main changes needed are:
+1. Updating host group from `k8s-control-node` to `microk8s_control_plane` 
+2. Ensuring variable compliance
+3. Creating proper test/rollback playbooks
+
+### Component Details
+- **Component Name**: GPU Operator
+- **Namespace**: gpu-operator
+- **Source**: thinkube-core migration (60_install_gpu_operator.yaml)
+- **Priority**: high
+- **Directory**: ansible/40_thinkube/core/infrastructure/gpu_operator/
+
+### Migration Checklist
+- [ ] Update host groups (`k8s-control-node` → `microk8s_control_plane`)
+- [ ] Move hardcoded values to inventory variables (minimal changes needed)
+- [ ] Update module names to FQCN (already compliant)
+- [ ] Verify variable compliance
+- [ ] Create proper test and rollback playbooks
+
+### Acceptance Criteria
+- [ ] GPU Operator deployed successfully
+- [ ] All GPU-operator components running (device plugin, driver, toolkit)
+- [ ] CUDA test job executes successfully
+- [ ] Documentation updated
+- [ ] Rollback playbook created (19_rollback.yaml)
+
+### Dependencies
+**Required Services:**
+- MicroK8s cluster with GPU-equipped nodes
+- NVIDIA drivers already installed on host systems (pre-verified)
+
+**Required Configurations:**
+- Proper containerd configuration for GPU support (already in place)
+- Helm must be available (already configured)
+
+### Hardcoded Values to Migrate
+- [ ] IP addresses: None found
+- [ ] Domain names: None found
+- [ ] Usernames: None found
+- [ ] Paths: `/tmp/cuda-vectoradd.yaml` - Consider using Ansible temp directory
+
+### TLS Certificate Changes
+- [ ] Current method: N/A (no certificate needed)
+- [ ] Cert-Manager resource needed: None
+- [ ] Domains required: None
+
+### Implementation Tasks
+1. [ ] Create component directory structure
+2. [ ] Create test playbook first (18_test.yaml)
+3. [ ] Migrate deployment playbook (10_deploy.yaml) with minimal changes
+4. [ ] Test deployment
+5. [ ] Create rollback playbook (19_rollback.yaml)
+6. [ ] Update documentation
+7. [ ] Create PR
+
+### Verification Steps
+```bash
+# 1. Check GPU resource availability
+microk8s kubectl get nodes -o json | jq '.items[].status.capacity["nvidia.com/gpu"]'
+
+# 2. Run test playbook
+./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/gpu_operator/18_test.yaml
+
+# 3. Verify components are running
+microk8s kubectl get pods -n gpu-operator
+```
+
+### Resource Requirements
+- CPU: 500m per component
+- Memory: 300Mi per component
+- Storage: None (stateless)
+
+### Edit History
+- 2025-05-21: Initial creation

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -108,17 +108,17 @@ This helps maintain accurate progress tracking between development sessions and 
   - [x] ⚠️ CONSOLIDATED INTO CORE-003b: Functionality merged into CoreDNS component
   - [x] Component removed to eliminate redundancy
 
-- [ ] **[CORE-003d] GPU Operator** ([Issue #44](https://github.com/cmxela/thinkube/issues/44))
+- [x] **[CORE-003d] GPU Operator** ([Issue #44](https://github.com/cmxela/thinkube/issues/44))
   - [x] Create/switch to branch: `git checkout -b feature/gpu-operator`
   - [x] Create issue document in .github/issues/CORE-003d-gpu-operator.md (completed)
-  - [ ] Create component directory structure
-  - [ ] Implement 10_deploy.yaml
-  - [ ] Implement 18_test.yaml
-  - [ ] Implement 19_rollback.yaml
-  - [ ] Test deployment
-  - [ ] Verify CUDA test job runs successfully
-  - [ ] Push changes to branch
-  - [ ] Create PR to main branch
+  - [x] Create component directory structure
+  - [x] Implement 10_deploy.yaml
+  - [x] Implement 18_test.yaml
+  - [x] Implement 19_rollback.yaml
+  - [x] Test deployment
+  - [x] Verify CUDA test job runs successfully on all GPU nodes
+  - [x] Push changes to branch
+  - [x] Create PR to main branch
 
 ### Core Platform Services [Individual Component Branches]
 

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -108,6 +108,18 @@ This helps maintain accurate progress tracking between development sessions and 
   - [x] ⚠️ CONSOLIDATED INTO CORE-003b: Functionality merged into CoreDNS component
   - [x] Component removed to eliminate redundancy
 
+- [ ] **[CORE-003d] GPU Operator** 
+  - [ ] Create/switch to branch: `git checkout -b feature/gpu-operator`
+  - [ ] Create issue document in .github/issues/CORE-003d-gpu-operator.md (completed)
+  - [ ] Create component directory structure
+  - [ ] Implement 10_deploy.yaml
+  - [ ] Implement 18_test.yaml
+  - [ ] Implement 19_rollback.yaml
+  - [ ] Test deployment
+  - [ ] Verify CUDA test job runs successfully
+  - [ ] Push changes to branch
+  - [ ] Create PR to main branch
+
 ### Core Platform Services [Individual Component Branches]
 
 - [ ] **[CORE-004] Keycloak** ([Issue #16](https://github.com/cmxela/thinkube/issues/16))

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -108,9 +108,9 @@ This helps maintain accurate progress tracking between development sessions and 
   - [x] ⚠️ CONSOLIDATED INTO CORE-003b: Functionality merged into CoreDNS component
   - [x] Component removed to eliminate redundancy
 
-- [ ] **[CORE-003d] GPU Operator** 
-  - [ ] Create/switch to branch: `git checkout -b feature/gpu-operator`
-  - [ ] Create issue document in .github/issues/CORE-003d-gpu-operator.md (completed)
+- [ ] **[CORE-003d] GPU Operator** ([Issue #44](https://github.com/cmxela/thinkube/issues/44))
+  - [x] Create/switch to branch: `git checkout -b feature/gpu-operator`
+  - [x] Create issue document in .github/issues/CORE-003d-gpu-operator.md (completed)
   - [ ] Create component directory structure
   - [ ] Implement 10_deploy.yaml
   - [ ] Implement 18_test.yaml

--- a/ansible/40_thinkube/core/infrastructure/gpu_operator/10_deploy.yaml
+++ b/ansible/40_thinkube/core/infrastructure/gpu_operator/10_deploy.yaml
@@ -1,0 +1,203 @@
+---
+# ansible/40_thinkube/core/infrastructure/gpu_operator/10_deploy.yaml
+# Description:
+#   Installs and configures NVIDIA GPU Operator on MicroK8s cluster
+#
+# Requirements:
+#   - MicroK8s >= 1.21
+#   - NVIDIA drivers >= 470.x already installed on the host system
+#   - kubernetes.core collection >= 2.3.0
+#   - Helm >= 3.7.0
+#
+# Usage:
+#   cd ~/thinkube
+#   ./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/gpu_operator/10_deploy.yaml
+#
+# Variables from inventory:
+#   - kubeconfig: Path to Kubernetes configuration file
+#   - kubectl_bin: Path to kubectl binary
+#   - helm_bin: Path to Helm binary
+#   - gpu_operator_version: (Optional) Version of GPU Operator to install
+#
+# 🤖 [AI-assisted]
+
+- name: Install NVIDIA GPU Operator
+  hosts: microk8s_control_plane
+  become: true
+  
+  pre_tasks:
+    - name: Verify required variables exist
+      ansible.builtin.fail:
+        msg: "Required variable {{ item }} is not defined"
+      when: item is not defined
+      loop:
+        - kubeconfig
+        - kubectl_bin
+        - helm_bin
+  
+  vars:
+    gpu_operator_namespace: gpu-operator
+    cuda_test_namespace: default
+    cuda_test_manifest: /tmp/cuda-vectoradd.yaml
+    cuda_test_pod: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: cuda-vectoradd
+        namespace: {{ cuda_test_namespace }}
+      spec:
+        restartPolicy: OnFailure
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          fsGroup: 1000
+        containers:
+        - name: cuda-vectoradd
+          image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubuntu20.04"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+
+  pre_tasks:
+    - name: Check MicroK8s status
+      ansible.builtin.command: microk8s status --wait-ready
+      changed_when: false
+      register: microk8s_status
+      until: microk8s_status.rc == 0
+      retries: 5
+      delay: 10
+
+  tasks:
+    - name: Create .kube directory
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.kube"
+        state: directory
+        mode: '0700'
+
+    - name: Copy kubeconfig
+      ansible.builtin.copy:
+        src: "{{ kubeconfig }}"
+        dest: "{{ ansible_env.HOME }}/.kube/config"
+        remote_src: yes
+        mode: '0600'
+
+    - name: Add NVIDIA Helm repository
+      kubernetes.core.helm_repository:
+        binary_path: "{{ helm_bin }}"
+        name: nvidia
+        repo_url: https://nvidia.github.io/gpu-operator
+        repo_state: present
+
+    - name: Update Helm repositories
+      ansible.builtin.command: "{{ helm_bin }} repo update"
+      changed_when: false
+
+    - name: Install GPU Operator
+      kubernetes.core.helm:
+        binary_path: "{{ helm_bin }}"
+        name: gpu-operator
+        chart_ref: nvidia/gpu-operator
+        chart_version: "{{ gpu_operator_version | default(omit) }}"
+        release_namespace: "{{ gpu_operator_namespace }}"
+        create_namespace: true
+        wait: true
+        values:
+          toolkit:
+            env:
+              - name: CONTAINERD_CONFIG
+                value: /var/snap/microk8s/current/args/containerd-template.toml
+              - name: CONTAINERD_SOCKET
+                value: /var/snap/microk8s/common/run/containerd.sock
+              - name: CONTAINERD_RUNTIME_CLASS
+                value: nvidia
+              - name: CONTAINERD_SET_AS_DEFAULT
+                value: "true"
+
+    - name: Wait for GPU operator critical components
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Pod
+        namespace: "{{ gpu_operator_namespace }}"
+        label_selectors:
+          - "app in (nvidia-device-plugin-daemonset,nvidia-container-toolkit-daemonset)"
+        field_selectors:
+          - status.phase=Running
+      register: gpu_pods
+      until: gpu_pods.resources | length >= 2
+      retries: 60
+      delay: 10
+
+    - name: Wait for CUDA validator completion
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Pod
+        namespace: "{{ gpu_operator_namespace }}"
+        label_selectors:
+          - app=nvidia-cuda-validator
+        field_selectors:
+          - status.phase=Succeeded
+      register: validator_pods
+      until: validator_pods.resources | length >= 1
+      retries: 60
+      delay: 10
+
+    - name: Create CUDA test manifest
+      ansible.builtin.copy:
+        content: "{{ cuda_test_pod }}"
+        dest: "{{ cuda_test_manifest }}"
+        mode: '0600'
+
+    - name: Deploy CUDA test pod
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        src: "{{ cuda_test_manifest }}"
+
+    - name: Wait for CUDA test pod completion
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Pod 
+        name: cuda-vectoradd
+        namespace: "{{ cuda_test_namespace }}"
+      register: cuda_pod
+      until: cuda_pod.resources[0].status.phase in ['Succeeded', 'Failed']
+      retries: 60
+      delay: 10
+
+    - name: Check CUDA test pod status
+      ansible.builtin.fail:
+        msg: "CUDA test pod failed: {{ cuda_pod.resources[0].status.phase }}"
+      when: cuda_pod.resources[0].status.phase == 'Failed'
+
+    - name: Get CUDA test pod logs
+      ansible.builtin.command: "{{ kubectl_bin }} logs cuda-vectoradd -n {{ cuda_test_namespace }}"
+      register: cuda_logs
+      changed_when: false
+
+    - name: Display CUDA test results
+      ansible.builtin.debug:
+        var: cuda_logs.stdout_lines
+
+    - name: Clean up CUDA test pod
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: absent
+        src: "{{ cuda_test_manifest }}"
+
+    - name: Remove temporary files
+      ansible.builtin.file:
+        path: "{{ cuda_test_manifest }}"
+        state: absent
+
+  post_tasks:
+    - name: Verify GPU operator status
+      ansible.builtin.command: "{{ kubectl_bin }} get nodes -o json"
+      register: node_status
+      changed_when: false
+      failed_when: "'nvidia.com/gpu' not in node_status.stdout"

--- a/ansible/40_thinkube/core/infrastructure/gpu_operator/18_test.yaml
+++ b/ansible/40_thinkube/core/infrastructure/gpu_operator/18_test.yaml
@@ -1,0 +1,190 @@
+---
+# ansible/40_thinkube/core/infrastructure/gpu_operator/18_test.yaml
+# Description:
+#   Tests NVIDIA GPU Operator deployment and functionality on all GPU nodes
+#   Verifies that all components are running and GPUs are available to the cluster
+#   Runs a CUDA test job on each GPU-equipped node to validate functionality
+#
+# Requirements:
+#   - MicroK8s cluster with GPU-equipped nodes
+#   - GPU Operator must be deployed
+#
+# Usage:
+#   cd ~/thinkube
+#   ./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/gpu_operator/18_test.yaml
+#
+# Variables from inventory:
+#   - kubeconfig: Path to Kubernetes configuration file
+#   - kubectl_bin: Path to kubectl binary
+#   - helm_bin: Path to Helm binary
+#
+# 🤖 [AI-assisted]
+
+- name: Test NVIDIA GPU Operator
+  hosts: microk8s_control_plane
+  gather_facts: true
+  
+  pre_tasks:
+    - name: Verify required variables exist
+      ansible.builtin.fail:
+        msg: "Required variable {{ item }} is not defined"
+      when: item is not defined
+      loop:
+        - kubeconfig
+        - kubectl_bin
+        - helm_bin
+  
+  vars:
+    gpu_operator_namespace: gpu-operator
+    cuda_test_namespace: default
+    cuda_test_manifest_base: /tmp/cuda-test
+    cuda_test_pod_template: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: cuda-test-{NODE_NAME}
+        namespace: {{ cuda_test_namespace }}
+      spec:
+        restartPolicy: OnFailure
+        nodeName: {NODE_NAME}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          fsGroup: 1000
+        containers:
+        - name: cuda-vectoradd
+          image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubuntu20.04"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+
+  tasks:
+    - name: Check that GPU Operator namespace exists
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Namespace
+        name: "{{ gpu_operator_namespace }}"
+      register: namespace_check
+      failed_when: namespace_check.resources | length == 0
+
+    - name: Check if GPU Operator is installed via Helm
+      ansible.builtin.command: "{{ helm_bin }} status gpu-operator -n {{ gpu_operator_namespace }}"
+      register: helm_status
+      changed_when: false
+      failed_when: helm_status.rc != 0
+
+    - name: Verify GPU operator pods are running
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Pod
+        namespace: "{{ gpu_operator_namespace }}"
+      register: operator_pods
+
+    - name: Count running pods by component
+      ansible.builtin.set_fact:
+        running_components: >-
+          {{ operator_pods.resources | 
+             selectattr('status.phase', 'equalto', 'Running') | 
+             list | length }}
+
+    - name: Check if critical components are running
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Pod
+        namespace: "{{ gpu_operator_namespace }}"
+        label_selectors:
+          - "app in (nvidia-device-plugin-daemonset,nvidia-container-toolkit-daemonset)"
+        field_selectors:
+          - status.phase=Running
+      register: critical_pods
+      failed_when: critical_pods.resources | length < 2
+
+    # Identify all GPU nodes in the cluster
+    - name: Get nodes with GPU resources
+      ansible.builtin.shell: >
+        {{ kubectl_bin }} get nodes -o=custom-columns=NAME:.metadata.name,GPU:.status.capacity.'nvidia\.com/gpu' --no-headers | 
+        grep -v '<none>' | awk '{print $1}'
+      register: gpu_nodes_result
+      changed_when: false
+      
+    - name: Set GPU nodes fact
+      ansible.builtin.set_fact:
+        gpu_nodes: "{{ gpu_nodes_result.stdout_lines }}"
+
+    - name: Display GPU nodes
+      ansible.builtin.debug:
+        var: gpu_nodes
+        
+    - name: Verify that at least one GPU node was found
+      ansible.builtin.assert:
+        that: gpu_nodes | length > 0
+        fail_msg: "No GPU nodes found in the cluster"
+        success_msg: "Found {{ gpu_nodes | length }} GPU node(s)"
+
+    # Run CUDA tests on each GPU node
+    - name: Initialize test results dictionary
+      ansible.builtin.set_fact:
+        node_test_results: {}
+        
+    - name: Create CUDA test manifest for GPU node
+      ansible.builtin.copy:
+        content: "{{ cuda_test_pod_template | replace('{NODE_NAME}', item) }}"
+        dest: "{{ cuda_test_manifest_base }}-{{ item }}.yaml"
+        mode: '0600'
+      loop: "{{ gpu_nodes }}"
+      loop_control:
+        label: "Preparing test for node {{ item }}"
+        
+    - name: Deploy CUDA test pod on GPU node
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        src: "{{ cuda_test_manifest_base }}-{{ item }}.yaml"
+      loop: "{{ gpu_nodes }}"
+      loop_control:
+        label: "Deploying test pod on node {{ item }}"
+        
+    # Process each node individually to avoid loop register issues
+    - name: Process CUDA test for each GPU node
+      include_tasks: tasks/test_node.yaml
+      loop: "{{ gpu_nodes }}"
+      loop_control:
+        loop_var: "current_node"
+        label: "Testing node {{ current_node }}"
+        
+    - name: Clean up CUDA test pods
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: absent
+        kind: Pod
+        name: "cuda-test-{{ item }}"
+        namespace: "{{ cuda_test_namespace }}"
+      loop: "{{ gpu_nodes }}"
+      loop_control:
+        label: "Cleaning up test pod on node {{ item }}"
+        
+    - name: Remove temporary manifests
+      ansible.builtin.file:
+        path: "{{ cuda_test_manifest_base }}-{{ item }}.yaml"
+        state: absent
+      loop: "{{ gpu_nodes }}"
+      loop_control:
+        label: "Removing manifest for node {{ item }}"
+
+    - name: Display test results summary
+      ansible.builtin.debug:
+        msg:
+          - "===== GPU OPERATOR TEST SUMMARY ====="
+          - "✅ GPU Operator Namespace: {{ 'Created' if namespace_check.resources | length > 0 else 'Missing' }}"
+          - "✅ GPU Operator Components Running: {{ running_components }} pods"
+          - "✅ Critical Components (device plugin, toolkit): {{ 'Running' if critical_pods.resources | length >= 2 else 'Some missing' }}"
+          - "✅ GPU Nodes: {{ gpu_nodes | length }} node(s) with GPUs"
+          - "✅ Node test results: {% for node, result in node_test_results.items() %} {{ node }}: {{ result }}{% if not loop.last %},{% endif %}{% endfor %}"
+          - "✅ Overall Status: {{ 'PASSED' if node_test_results.values() | select('equalto', 'Succeeded') | list | length == gpu_nodes | length else 'FAILED' }}"
+          - "=================================="

--- a/ansible/40_thinkube/core/infrastructure/gpu_operator/19_rollback.yaml
+++ b/ansible/40_thinkube/core/infrastructure/gpu_operator/19_rollback.yaml
@@ -1,0 +1,99 @@
+---
+# ansible/40_thinkube/core/infrastructure/gpu_operator/19_rollback.yaml
+# Description:
+#   Removes NVIDIA GPU Operator from the MicroK8s cluster
+#   Cleans up all resources created by the deployment
+#
+# Requirements:
+#   - MicroK8s cluster
+#   - Helm must be available
+#
+# Usage:
+#   cd ~/thinkube
+#   ./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/gpu_operator/19_rollback.yaml
+#
+# Variables from inventory:
+#   - kubeconfig: Path to Kubernetes configuration file
+#   - kubectl_bin: Path to kubectl binary
+#   - helm_bin: Path to Helm binary
+#
+# 🤖 [AI-assisted]
+
+- name: Rollback NVIDIA GPU Operator
+  hosts: microk8s_control_plane
+  gather_facts: true
+  
+  pre_tasks:
+    - name: Verify required variables exist
+      ansible.builtin.fail:
+        msg: "Required variable {{ item }} is not defined"
+      when: item is not defined
+      loop:
+        - kubeconfig
+        - kubectl_bin
+        - helm_bin
+  
+  vars:
+    gpu_operator_namespace: gpu-operator
+    cuda_test_namespace: default
+    cuda_test_pod_name: cuda-vectoradd
+    
+  tasks:
+    - name: Check if CUDA test pod exists
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Pod
+        name: "{{ cuda_test_pod_name }}"
+        namespace: "{{ cuda_test_namespace }}"
+      register: test_pod_check
+      failed_when: false
+      
+    - name: Remove CUDA test pod if it exists
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: absent
+        kind: Pod
+        name: "{{ cuda_test_pod_name }}"
+        namespace: "{{ cuda_test_namespace }}"
+      when: test_pod_check.resources | length > 0
+    
+    - name: Check if GPU Operator is installed via Helm
+      ansible.builtin.command: "{{ helm_bin }} status gpu-operator -n {{ gpu_operator_namespace }}"
+      register: helm_status
+      changed_when: false
+      failed_when: false
+      
+    - name: Uninstall GPU Operator via Helm
+      ansible.builtin.command: "{{ helm_bin }} uninstall gpu-operator -n {{ gpu_operator_namespace }}"
+      when: helm_status.rc == 0
+      register: helm_uninstall
+      changed_when: helm_uninstall.rc == 0
+      
+    - name: Wait for pods to be terminated
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        kind: Pod
+        namespace: "{{ gpu_operator_namespace }}"
+      register: gpu_pods
+      until: gpu_pods.resources | length == 0
+      retries: 30
+      delay: 5
+      when: helm_uninstall is defined and helm_uninstall.rc == 0
+      failed_when: false
+      
+    - name: Delete GPU Operator namespace
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: absent
+        kind: Namespace
+        name: "{{ gpu_operator_namespace }}"
+      register: delete_namespace
+      changed_when: delete_namespace is changed
+      
+    - name: Display rollback status
+      ansible.builtin.debug:
+        msg:
+          - "GPU Operator rollback status:"
+          - "Helm release: {{ 'Removed' if helm_status.rc == 0 and helm_uninstall is defined else 'Not found' }}"
+          - "Namespace: {{ 'Deleted' if delete_namespace is changed else 'Not found or could not be deleted' }}"
+          - "Test pod: {{ 'Removed' if test_pod_check.resources | length > 0 else 'Not found' }}"

--- a/ansible/40_thinkube/core/infrastructure/gpu_operator/README.md
+++ b/ansible/40_thinkube/core/infrastructure/gpu_operator/README.md
@@ -1,0 +1,71 @@
+# NVIDIA GPU Operator
+
+This component deploys the NVIDIA GPU Operator in the MicroK8s cluster, enabling GPU support for containerized workloads.
+
+## Description
+
+The NVIDIA GPU Operator is a Kubernetes operator that automates the management of NVIDIA GPUs in Kubernetes clusters. It manages the installation and lifecycle of several components:
+
+- NVIDIA drivers
+- NVIDIA container toolkit
+- NVIDIA Kubernetes device plugin
+- NVIDIA MIG manager (if applicable)
+
+## Requirements
+
+- MicroK8s cluster with at least one GPU-equipped node
+- NVIDIA drivers installed on the host systems
+- Helm 3.x installed
+- kubernetes.core collection >= 2.3.0
+
+## Usage
+
+Deploy the GPU Operator:
+```bash
+cd ~/thinkube
+./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/gpu_operator/10_deploy.yaml
+```
+
+Test the GPU Operator:
+```bash
+./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/gpu_operator/18_test.yaml
+```
+
+Rollback the GPU Operator:
+```bash
+./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/gpu_operator/19_rollback.yaml
+```
+
+## Configuration
+
+The following inventory variables can be used to configure the GPU Operator:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| gpu_operator_version | Version of the GPU Operator to install | Latest |
+
+## Testing
+
+The 18_test.yaml playbook tests all aspects of the GPU Operator:
+
+1. Checks if all components are installed and running
+2. Verifies that GPU resources are available on the nodes
+3. Runs a CUDA workload on each GPU node to validate functionality
+
+## Troubleshooting
+
+If the deployment fails, check the following:
+
+1. Ensure NVIDIA drivers are correctly installed on the host system
+2. Check for errors in the GPU operator pods: 
+   ```
+   microk8s kubectl get pods -n gpu-operator
+   ```
+3. Examine logs of any pods in error state:
+   ```
+   microk8s kubectl logs -n gpu-operator <pod-name>
+   ```
+4. Verify containerd configuration in MicroK8s:
+   ```
+   cat /var/snap/microk8s/current/args/containerd-template.toml
+   ```

--- a/ansible/40_thinkube/core/infrastructure/gpu_operator/tasks/test_node.yaml
+++ b/ansible/40_thinkube/core/infrastructure/gpu_operator/tasks/test_node.yaml
@@ -1,0 +1,35 @@
+---
+# Tasks for testing CUDA on a single GPU node
+
+- name: Wait for CUDA test pod completion
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ kubeconfig }}"
+    kind: Pod 
+    name: "cuda-test-{{ current_node }}"
+    namespace: "{{ cuda_test_namespace }}"
+  register: cuda_pod_status
+  until: "cuda_pod_status.resources | length > 0 and cuda_pod_status.resources[0].status.phase in ['Succeeded', 'Failed']"
+  retries: 60
+  delay: 10
+
+- name: Record test result for node
+  ansible.builtin.set_fact:
+    node_test_results: "{{ node_test_results | default({}) | combine({current_node: cuda_pod_status.resources[0].status.phase}) }}"
+
+- name: Check for test failure
+  ansible.builtin.fail:
+    msg: "CUDA test on node {{ current_node }} failed with status: {{ cuda_pod_status.resources[0].status.phase }}"
+  when: cuda_pod_status.resources[0].status.phase == 'Failed'
+
+- name: Get CUDA test pod logs
+  ansible.builtin.command: "{{ kubectl_bin }} logs cuda-test-{{ current_node }} -n {{ cuda_test_namespace }}"
+  register: cuda_logs
+  changed_when: false
+
+- name: Display CUDA test results for node
+  ansible.builtin.debug:
+    msg: 
+      - "Node: {{ current_node }}"
+      - "Status: {{ cuda_pod_status.resources[0].status.phase }}"
+      - "Log excerpt:"
+      - "{{ cuda_logs.stdout_lines[-5:] if cuda_logs.stdout_lines | length > 5 else cuda_logs.stdout_lines }}"


### PR DESCRIPTION
## Summary
- Add NVIDIA GPU Operator deployment for hardware-accelerated Kubernetes workloads
- Enable containerd configuration for MicroK8s integration with GPU resources
- Implement comprehensive testing to verify GPU availability on all nodes

## Test plan
- Verify GPU Operator namespace and Helm release exist
- Confirm critical components like device plugin and container toolkit are running
- Automatically detect all GPU-equipped nodes in the cluster
- Run CUDA test jobs on each detected GPU node to validate end-to-end functionality
- Test rollback functionality for clean uninstallation

Closes #44

🤖 Generated with [Claude Code](https://claude.ai/code)